### PR TITLE
feat(csproj): persist source generator output to disk

### DIFF
--- a/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Client.cs
+++ b/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Client.cs
@@ -76,7 +76,7 @@ public partial class RpcServiceGenerator
 
       namespace {{namespaceName}}
       {
-      // server {{hasServer}} client {{hasClient}}
+        // server {{hasServer}} client {{hasClient}}
         public partial class {{className}}
         {
           public Lakerfield.Rpc.NetworkClient Client { get; }
@@ -86,7 +86,7 @@ public partial class RpcServiceGenerator
             Client = client;
           }
 
-          {{methodSourceBuilder.ToString()}}
+      {{methodSourceBuilder.ToString()}}
         }
       }
 

--- a/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Server.cs
+++ b/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Server.cs
@@ -71,6 +71,7 @@ public partial class RpcServiceGenerator
                             throw new NotImplementedException("{{methodName}} of {{serviceSymbol.Name}} is not implemented");
                           }
 
+
                     """);
       else if (!hasMethod && isObservable)
         methodSourceBuilder
@@ -81,9 +82,10 @@ public partial class RpcServiceGenerator
                             throw new NotImplementedException("{{methodName}} of {{serviceSymbol.Name}} is not implemented");
                           }
 
+
                     """);
       else
-        methodSourceBuilder.AppendLine($"// {methodName} already implemented");
+        methodSourceBuilder.AppendLine($"      // {methodName} already implemented");
 
       if (isTask)
         methodSourceBuilder
@@ -97,6 +99,7 @@ public partial class RpcServiceGenerator
                             };
                           }
 
+
                     """);
 
       if (isObservable)
@@ -107,6 +110,7 @@ public partial class RpcServiceGenerator
                           {
                             return new Lakerfield.Rpc.NetworkObservable<{{returnTypeGenericType1}}>({{methodName}}({{switchParameters}}));
                           }
+
 
                     """);
 
@@ -153,11 +157,18 @@ namespace {{namespaceName}}
         if (message == null)
           throw new ArgumentNullException("message", "Cannot route null RpcMessage");
 
-System.Console.WriteLine($"new message {message.GetType().Name}");
+#if DEBUG
+        System.Console.WriteLine($"new message {message.GetType().Name}");
+#endif
         return message switch {
 {{taskSwitchSourceBuilder.ToString()}}
           _ => TaskNotImplementedMessage(message)
         };
+      }
+
+      private Task<Lakerfield.Rpc.RpcMessage> TaskNotImplementedMessage(Lakerfield.Rpc.RpcMessage message)
+      {
+        throw new NotImplementedException(string.Format("Message {0} not implemented", message.GetType().Name));
       }
 
       public Lakerfield.Rpc.NetworkObservable HandleObservable(Lakerfield.Rpc.RpcMessage message)
@@ -165,16 +176,13 @@ System.Console.WriteLine($"new message {message.GetType().Name}");
         if (message == null)
           throw new ArgumentNullException("message", "Cannot route null RpcMessage");
 
-System.Console.WriteLine($"new message {message.GetType().Name}");
+#if DEBUG
+        System.Console.WriteLine($"new message {message.GetType().Name}");
+#endif
         return message switch {
 {{observableSwitchSourceBuilder.ToString()}}
           _ => ObservableNotImplementedMessage(message)
         };
-      }
-
-      private Task<Lakerfield.Rpc.RpcMessage> TaskNotImplementedMessage(Lakerfield.Rpc.RpcMessage message)
-      {
-        throw new NotImplementedException(string.Format("Message {0} not implemented", message.GetType().Name));
       }
 
       private Lakerfield.Rpc.NetworkObservable ObservableNotImplementedMessage(Lakerfield.Rpc.RpcMessage message)

--- a/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Service.cs
+++ b/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.Service.cs
@@ -46,17 +46,18 @@ public partial class RpcServiceGenerator
       foreach (var memberParameter in member.Parameters)
       {
         methodPropertiesSourceBuilder.AppendLine(
-          $"        public {memberParameter.Type} {CapitalizeFirstLetter(memberParameter.Name)} {{ get; set; }}");
+          $"    public {memberParameter.Type} {CapitalizeFirstLetter(memberParameter.Name)} {{ get; set; }}");
       }
 
       if (isTask || isObservable)
       {  requestResponseModelsSourceBuilder
           .Append($$"""
-                          //[EditorBrowsable(EditorBrowsableState.Never)]
-                          public class {{methodName}}Request : Lakerfield.Rpc.RpcMessage
-                          {
+                      //[EditorBrowsable(EditorBrowsableState.Never)]
+                      public class {{methodName}}Request : Lakerfield.Rpc.RpcMessage
+                      {
                     {{methodPropertiesSourceBuilder.ToString()}}
-                          }
+                      }
+
 
                     """);
         bsonClassMapsSourceBuilder
@@ -70,11 +71,13 @@ public partial class RpcServiceGenerator
       {
         requestResponseModelsSourceBuilder
           .Append($$"""
-                          //[EditorBrowsable(EditorBrowsableState.Never)]
-                          public class {{methodName}}Response: Lakerfield.Rpc.RpcMessage
-                          {
-                            public {{returnTypeExTask}} Result { get; set; }
-                          }
+                      //[EditorBrowsable(EditorBrowsableState.Never)]
+                      public class {{methodName}}Response: Lakerfield.Rpc.RpcMessage
+                      {
+                        public {{returnTypeExTask}} Result { get; set; }
+                      }
+
+
 
 
                     """);
@@ -113,6 +116,7 @@ namespace {{namespaceName}}
       _configured = true;
 
       PreConfigure();
+
 {{bsonClassMapsSourceBuilder.ToString()}}
       PostConfigure();
     }

--- a/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.cs
+++ b/src/Lakerfield.Rpc.SourceGenerator/RpcServiceGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -24,13 +24,16 @@ namespace Lakerfield.Rpc
   internal sealed class RpcServiceAttribute : Attribute
   {
   }
+
   internal sealed class RpcServerAttribute : Attribute
   {
   }
+
   internal sealed class RpcClientAttribute : Attribute
   {
   }
 }
+
 """, Encoding.UTF8));
     });
 
@@ -62,9 +65,6 @@ namespace Lakerfield.Rpc
       .Where(m => m is not null)
       .Select((symbol, _) => (INamedTypeSymbol)symbol!)
       .Collect();
-
-    // // Register the source generator to generate the implementation class
-    // context.RegisterSourceOutput(interfacesWithAttribute, (spc, symbols) => Execute(spc, symbols));
 
     // Combine the dependency check with the source generator logic
     var combined = interfacesWithAttribute.Combine(hasServerDependencyCheck).Combine(hasClientDependencyCheck);

--- a/src/Lakerfield.RpcTest.ClientApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
+++ b/src/Lakerfield.RpcTest.ClientApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Lakerfield.Rpc
+{
+  internal sealed class RpcServiceAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcServerAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcClientAttribute : Attribute
+  {
+  }
+}

--- a/src/Lakerfield.RpcTest.ClientApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestServiceClient.client.g.cs
+++ b/src/Lakerfield.RpcTest.ClientApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestServiceClient.client.g.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Lakerfield.RpcTest;
+
+namespace Lakerfield.RpcTest
+{
+  // server False client True
+  public partial class RpcTestServiceClient
+  {
+    public Lakerfield.Rpc.NetworkClient Client { get; }
+    public RpcTestServiceClient(Lakerfield.Rpc.NetworkClient client)
+    {
+      RpcTestServiceBsonConfigurator.Configure();
+      Client = client;
+    }
+
+    public async System.Threading.Tasks.Task<Lakerfield.RpcTest.Models.Company> CompanyFindById(System.Guid id)
+    {
+      var request = new CompanyFindByIdRequest() { Id = id };
+      var response = await Client.Execute<CompanyFindByIdResponse>(request).ConfigureAwait(false);
+      return response.Result;
+    }
+
+    public async System.Threading.Tasks.Task<Lakerfield.RpcTest.Models.Company[]> CompanyFindAll()
+    {
+      var request = new CompanyFindAllRequest() {  };
+      var response = await Client.Execute<CompanyFindAllResponse>(request).ConfigureAwait(false);
+      return response.Result;
+    }
+
+    public async System.Threading.Tasks.Task<Lakerfield.RpcTest.Models.Company> CompanySave(Lakerfield.RpcTest.Models.Company entity)
+    {
+      var request = new CompanySaveRequest() { Entity = entity };
+      var response = await Client.Execute<CompanySaveResponse>(request).ConfigureAwait(false);
+      return response.Result;
+    }
+
+    public async System.Threading.Tasks.Task<bool> CompanyDelete(Lakerfield.RpcTest.Models.Company entity)
+    {
+      var request = new CompanyDeleteRequest() { Entity = entity };
+      var response = await Client.Execute<CompanyDeleteResponse>(request).ConfigureAwait(false);
+      return response.Result;
+    }
+
+    public async System.Threading.Tasks.Task<(Lakerfield.RpcTest.Models.Company, string)> CompanyTest(Lakerfield.RpcTest.Models.Company entity, Lakerfield.RpcTest.Models.Company entity2, string wouter, int bert)
+    {
+      var request = new CompanyTestRequest() { Entity = entity, Entity2 = entity2, Wouter = wouter, Bert = bert };
+      var response = await Client.Execute<CompanyTestResponse>(request).ConfigureAwait(false);
+      return response.Result;
+    }
+
+    public System.IObservable<Lakerfield.RpcTest.Models.Company> GetObservable(System.Guid id)
+    {
+      var request = new GetObservableRequest() { Id = id };
+      var result = Client.ExecuteObservable<Lakerfield.RpcTest.Models.Company>(request);
+      return result;
+    }
+
+
+  }
+}

--- a/src/Lakerfield.RpcTest.ClientApp/Lakerfield.RpcTest.ClientApp.csproj
+++ b/src/Lakerfield.RpcTest.ClientApp/Lakerfield.RpcTest.ClientApp.csproj
@@ -17,4 +17,18 @@
     <ProjectReference Include="..\Lakerfield.Rpc.SourceGenerator\Lakerfield.Rpc.SourceGenerator.csproj" PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Persist the source generator (and other) files to disk (https://andrewlock.net/creating-a-source-generator-part-6-saving-source-generator-output-in-source-control/) -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- The "base" path for the source generators -->
+    <GeneratedFolder>Generated</GeneratedFolder>
+    <!-- Write the output for each target framework to a different sub-folder -->
+    <CompilerGeneratedFilesOutputPath>$(GeneratedFolder)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude everything in the generated folder for compilation -->
+    <Compile Remove="$(GeneratedFolder)/**/*.cs" />
+  </ItemGroup>
+  
 </Project>

--- a/src/Lakerfield.RpcTest.ServerApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
+++ b/src/Lakerfield.RpcTest.ServerApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Lakerfield.Rpc
+{
+  internal sealed class RpcServiceAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcServerAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcClientAttribute : Attribute
+  {
+  }
+}

--- a/src/Lakerfield.RpcTest.ServerApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestServiceServer.server.g.cs
+++ b/src/Lakerfield.RpcTest.ServerApp/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestServiceServer.server.g.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.ComponentModel;
+using System.Net;
+using System.Threading.Tasks;
+using Lakerfield.RpcTest;
+
+namespace Lakerfield.RpcTest
+{
+  // server True client False from Lakerfield.RpcTest.IRpcTestService
+  public partial class RpcTestServiceServer
+  {
+    public RpcTestServiceServer(IPEndPoint endPoint) : base (endPoint)
+    {
+    }
+
+    public override void InitBsonClassMaps()
+    {
+      RpcTestServiceBsonConfigurator.Configure();
+    }
+
+    //public override Lakerfield.Rpc.ILakerfieldRpcClientMessageHandler CreateConnectionMessageRouter(Lakerfield.Rpc.LakerfieldRpcServerConnection connection)
+    //{
+    //  return new Lakerfield.Rpc.LakerfieldRpcMessageRouter(connection);
+    //}
+
+    public partial class ClientConnectionMessageHandler : Lakerfield.Rpc.ILakerfieldRpcClientMessageHandler
+    {
+      public Lakerfield.Rpc.LakerfieldRpcServerConnection Connection { get; }
+
+      public ClientConnectionMessageHandler(Lakerfield.Rpc.LakerfieldRpcServerConnection connection)
+      {
+        Connection = connection;
+      }
+
+      public Task<Lakerfield.Rpc.RpcMessage> HandleMessage(Lakerfield.Rpc.RpcMessage message)
+      {
+        if (message == null)
+          throw new ArgumentNullException("message", "Cannot route null RpcMessage");
+
+#if DEBUG
+        System.Console.WriteLine($"new message {message.GetType().Name}");
+#endif
+        return message switch {
+          CompanyFindByIdRequest request => _CompanyFindById(request),
+          CompanyFindAllRequest request => _CompanyFindAll(request),
+          CompanySaveRequest request => _CompanySave(request),
+          CompanyDeleteRequest request => _CompanyDelete(request),
+          CompanyTestRequest request => _CompanyTest(request),
+
+          _ => TaskNotImplementedMessage(message)
+        };
+      }
+
+      private Task<Lakerfield.Rpc.RpcMessage> TaskNotImplementedMessage(Lakerfield.Rpc.RpcMessage message)
+      {
+        throw new NotImplementedException(string.Format("Message {0} not implemented", message.GetType().Name));
+      }
+
+      public Lakerfield.Rpc.NetworkObservable HandleObservable(Lakerfield.Rpc.RpcMessage message)
+      {
+        if (message == null)
+          throw new ArgumentNullException("message", "Cannot route null RpcMessage");
+
+#if DEBUG
+        System.Console.WriteLine($"new message {message.GetType().Name}");
+#endif
+        return message switch {
+          GetObservableRequest request => _GetObservable(request),
+
+          _ => ObservableNotImplementedMessage(message)
+        };
+      }
+
+      private Lakerfield.Rpc.NetworkObservable ObservableNotImplementedMessage(Lakerfield.Rpc.RpcMessage message)
+      {
+        throw new NotImplementedException(string.Format("Message {0} not implemented", message.GetType().Name));
+      }
+
+      // CompanyFindById already implemented
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public async Task<Lakerfield.Rpc.RpcMessage> _CompanyFindById(CompanyFindByIdRequest request)
+      {
+        return new CompanyFindByIdResponse()
+        {
+          Result = await CompanyFindById(request.Id).ConfigureAwait(false)
+        };
+      }
+
+      #warning CompanyFindAll of IRpcTestService is not implemented
+      public System.Threading.Tasks.Task<Lakerfield.RpcTest.Models.Company[]> CompanyFindAll()
+      {
+        throw new NotImplementedException("CompanyFindAll of IRpcTestService is not implemented");
+      }
+
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public async Task<Lakerfield.Rpc.RpcMessage> _CompanyFindAll(CompanyFindAllRequest request)
+      {
+        return new CompanyFindAllResponse()
+        {
+          Result = await CompanyFindAll().ConfigureAwait(false)
+        };
+      }
+
+      #warning CompanySave of IRpcTestService is not implemented
+      public System.Threading.Tasks.Task<Lakerfield.RpcTest.Models.Company> CompanySave(Lakerfield.RpcTest.Models.Company entity)
+      {
+        throw new NotImplementedException("CompanySave of IRpcTestService is not implemented");
+      }
+
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public async Task<Lakerfield.Rpc.RpcMessage> _CompanySave(CompanySaveRequest request)
+      {
+        return new CompanySaveResponse()
+        {
+          Result = await CompanySave(request.Entity).ConfigureAwait(false)
+        };
+      }
+
+      #warning CompanyDelete of IRpcTestService is not implemented
+      public System.Threading.Tasks.Task<bool> CompanyDelete(Lakerfield.RpcTest.Models.Company entity)
+      {
+        throw new NotImplementedException("CompanyDelete of IRpcTestService is not implemented");
+      }
+
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public async Task<Lakerfield.Rpc.RpcMessage> _CompanyDelete(CompanyDeleteRequest request)
+      {
+        return new CompanyDeleteResponse()
+        {
+          Result = await CompanyDelete(request.Entity).ConfigureAwait(false)
+        };
+      }
+
+      #warning CompanyTest of IRpcTestService is not implemented
+      public System.Threading.Tasks.Task<(Lakerfield.RpcTest.Models.Company, string)> CompanyTest(Lakerfield.RpcTest.Models.Company entity, Lakerfield.RpcTest.Models.Company entity2, string wouter, int bert)
+      {
+        throw new NotImplementedException("CompanyTest of IRpcTestService is not implemented");
+      }
+
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public async Task<Lakerfield.Rpc.RpcMessage> _CompanyTest(CompanyTestRequest request)
+      {
+        return new CompanyTestResponse()
+        {
+          Result = await CompanyTest(request.Entity, request.Entity2, request.Wouter, request.Bert).ConfigureAwait(false)
+        };
+      }
+
+      // GetObservable already implemented
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      public Lakerfield.Rpc.NetworkObservable _GetObservable(GetObservableRequest request)
+      {
+        return new Lakerfield.Rpc.NetworkObservable<Lakerfield.RpcTest.Models.Company>(GetObservable(request.Id));
+      }
+
+
+
+    }
+  }
+}

--- a/src/Lakerfield.RpcTest.ServerApp/Lakerfield.RpcTest.ServerApp.csproj
+++ b/src/Lakerfield.RpcTest.ServerApp/Lakerfield.RpcTest.ServerApp.csproj
@@ -20,5 +20,19 @@
   <ItemGroup>
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
-  
+
+  <PropertyGroup>
+    <!-- Persist the source generator (and other) files to disk (https://andrewlock.net/creating-a-source-generator-part-6-saving-source-generator-output-in-source-control/) -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- The "base" path for the source generators -->
+    <GeneratedFolder>Generated</GeneratedFolder>
+    <!-- Write the output for each target framework to a different sub-folder -->
+    <CompilerGeneratedFilesOutputPath>$(GeneratedFolder)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude everything in the generated folder for compilation -->
+    <Compile Remove="$(GeneratedFolder)/**/*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Lakerfield.RpcTest/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
+++ b/src/Lakerfield.RpcTest/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcAttributes.g.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Lakerfield.Rpc
+{
+  internal sealed class RpcServiceAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcServerAttribute : Attribute
+  {
+  }
+
+  internal sealed class RpcClientAttribute : Attribute
+  {
+  }
+}

--- a/src/Lakerfield.RpcTest/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestService.service.g.cs
+++ b/src/Lakerfield.RpcTest/Generated/net8.0/Lakerfield.Rpc.SourceGenerator/Lakerfield.Rpc.RpcServiceGenerator/RpcTestService.service.g.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Lakerfield.RpcTest
+{
+  // server False client False
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyFindByIdRequest : Lakerfield.Rpc.RpcMessage
+  {
+    public System.Guid Id { get; set; }
+
+  }
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyFindByIdResponse: Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company Result { get; set; }
+  }
+
+
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyFindAllRequest : Lakerfield.Rpc.RpcMessage
+  {
+
+  }
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyFindAllResponse: Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company[] Result { get; set; }
+  }
+
+
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanySaveRequest : Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company Entity { get; set; }
+
+  }
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanySaveResponse: Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company Result { get; set; }
+  }
+
+
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyDeleteRequest : Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company Entity { get; set; }
+
+  }
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyDeleteResponse: Lakerfield.Rpc.RpcMessage
+  {
+    public bool Result { get; set; }
+  }
+
+
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyTestRequest : Lakerfield.Rpc.RpcMessage
+  {
+    public Lakerfield.RpcTest.Models.Company Entity { get; set; }
+    public Lakerfield.RpcTest.Models.Company Entity2 { get; set; }
+    public string Wouter { get; set; }
+    public int Bert { get; set; }
+
+  }
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class CompanyTestResponse: Lakerfield.Rpc.RpcMessage
+  {
+    public (Lakerfield.RpcTest.Models.Company, string) Result { get; set; }
+  }
+
+
+
+  //[EditorBrowsable(EditorBrowsableState.Never)]
+  public class GetObservableRequest : Lakerfield.Rpc.RpcMessage
+  {
+    public System.Guid Id { get; set; }
+
+  }
+
+
+
+  public static partial class RpcTestServiceBsonConfigurator
+  {
+
+    private static bool _configured = false;
+    public static void Configure()
+    {
+      if (_configured)
+        return;
+
+      _configured = true;
+
+      PreConfigure();
+
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyFindByIdRequest>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyFindByIdResponse>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyFindAllRequest>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyFindAllResponse>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanySaveRequest>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanySaveResponse>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyDeleteRequest>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyDeleteResponse>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyTestRequest>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<CompanyTestResponse>(AutoMap);
+      Lakerfield.Bson.Serialization.BsonClassMap.RegisterClassMap<GetObservableRequest>(AutoMap);
+
+      PostConfigure();
+    }
+
+    static partial void PreConfigure();
+    static partial void PostConfigure();
+
+    private static void AutoMap<T>(Lakerfield.Bson.Serialization.BsonClassMap<T> cm)
+    {
+      cm.AutoMap();
+    }
+
+    private static void AutoMapAndSetGenericDiscriminator(Lakerfield.Bson.Serialization.BsonClassMap cm)
+    {
+      cm.AutoMap();
+
+      var cmType = cm.GetType();
+      var cmGenericType = cmType.GenericTypeArguments.First();
+      var discriminator = cmGenericType.Name;
+      var cmGenericTypeType = cmGenericType.GenericTypeArguments.FirstOrDefault();
+      if (cmGenericTypeType != null)
+        discriminator += cmGenericTypeType.Name;
+      cm.SetDiscriminator(discriminator);
+    }
+
+  }
+
+}

--- a/src/Lakerfield.RpcTest/Lakerfield.RpcTest.csproj
+++ b/src/Lakerfield.RpcTest/Lakerfield.RpcTest.csproj
@@ -15,4 +15,18 @@
     <ProjectReference Include="..\Lakerfield.Rpc\Lakerfield.Rpc.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Persist the source generator (and other) files to disk (https://andrewlock.net/creating-a-source-generator-part-6-saving-source-generator-output-in-source-control/) -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- The "base" path for the source generators -->
+    <GeneratedFolder>Generated</GeneratedFolder>
+    <!-- Write the output for each target framework to a different sub-folder -->
+    <CompilerGeneratedFilesOutputPath>$(GeneratedFolder)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Exclude everything in the generated folder for compilation -->
+    <Compile Remove="$(GeneratedFolder)/**/*.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This change adds configuration to the RpcTest projects to persist the source generator output to disk. This ensures that the generated files are included in source control.